### PR TITLE
Fix GH Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build site
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
   deploy:


### PR DESCRIPTION
## Summary
- upgrade to `actions/upload-pages-artifact@v3` to avoid using the deprecated
`upload-artifact@v3`

## Testing
- `npm ci`
- `npm run lint`
- `npm run test --if-present`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68654cd33f2083288340cf7d3775eefc