### PR TITLE
Configure GitHub Pages base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 This site is automatically built and deployed to **GitHub Pages** using the `pages.yml` workflow.
 
+The project uses Next.js export mode to generate static files. Because the site
+is served from `/my-site` on GitHub Pages, `next.config.ts` sets `basePath` and
+`assetPrefix` to `/my-site`. Running `npm run build` outputs the site to the
+`out` directory, which the workflow publishes automatically. Update these paths
+if you deploy to a different location.
+
 ## Getting Started
 
 First, run the development server:

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Enable static HTML export for GitHub Pages
   output: "export",
+  basePath: "/my-site",
+  assetPrefix: "/my-site",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure `basePath` and `assetPrefix` in `next.config.ts`
- document the GitHub Pages static build process and base path

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686552e3422883289de86de5f879b6a4